### PR TITLE
#901 additional geographic information columns has been added in core…

### DIFF
--- a/dbt_doc_blocks/column_descriptions.md
+++ b/dbt_doc_blocks/column_descriptions.md
@@ -1037,3 +1037,16 @@ Unique year-month of in the dataset computed from eligibility.
 {% docs zip_code %}
 The zip code of the record (e.g., facility location, patient, etc).
 {% enddocs %}
+
+{% docs fips_state_code %}
+FIPS code for the state the patient lives in (most recent known address).
+{% enddocs %}
+
+{% docs normalized_state_name %}
+State for the patient (most recent known address).
+{% enddocs%}
+
+{% docs fips_state_abbreviation %}
+Abbreviated form of the state for the patient (most recient known address).
+{% enddocs%}
+      

--- a/models/claims_preprocessing/claims_preprocessing_models.yml
+++ b/models/claims_preprocessing/claims_preprocessing_models.yml
@@ -1271,3 +1271,10 @@ models:
       tags: 
         - normalized_input
         - claims_preprocessing
+
+  - name: normalized_input__int_eligibility_state_normalize
+    config:
+      materialized: ephemeral
+      tags: 
+        - normalized_input
+        - claims_preprocessing

--- a/models/claims_preprocessing/claims_preprocessing_models.yml
+++ b/models/claims_preprocessing/claims_preprocessing_models.yml
@@ -188,6 +188,12 @@ models:
         description: State the patient lives in (most recent known address)
       - name: zip_code
         description: Zip code the patient lives in (most recent known address).
+      - name: fips_state_code
+        description: FIPS code for the state the patient lives in (most recent known address).
+      - name: normalized_state_name
+        description: State for the patient (most recent known address).
+      - name: fips_state_abbreviation
+        description: Abbreviated form of the state for the patient (most recient known address).
       - name: phone
         description: Patient's phone number.
       - name: data_source

--- a/models/claims_preprocessing/normalized_input/final/normalized_input__eligibility.sql
+++ b/models/claims_preprocessing/normalized_input/final/normalized_input__eligibility.sql
@@ -32,14 +32,14 @@ select
   , cast(elig.city as {{ dbt.type_string() }}) as city
   , cast(elig.state as {{ dbt.type_string() }}) as state
   , cast(elig.zip_code as {{ dbt.type_string() }}) as zip_code
-  , cast(ansi.ansi_fips_state_code as {{ dbt.type_string() }}) as fips_state_code
-  , cast(ansi.ansi_fips_state_name as {{ dbt.type_string() }}) as normalized_state_name
-  , cast(ansi.ansi_fips_state_abbreviation as {{ dbt.type_string() }}) as fips_state_abbreviation
+  , cast(ansi.fips_state_code as {{ dbt.type_string() }}) as fips_state_code
+  , cast(ansi.normalized_state_name as {{ dbt.type_string() }}) as normalized_state_name
+  , cast(ansi.fips_state_abbreviation as {{ dbt.type_string() }}) as fips_state_abbreviation
   , cast(elig.phone as {{ dbt.type_string() }}) as phone
   , cast(elig.data_source as {{ dbt.type_string() }}) as data_source
   , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_string() }}) as tuva_last_run
 from {{ ref('normalized_input__stg_eligibility') }} as elig
 left outer join {{ ref('normalized_input__int_eligibility_dates_normalize') }} as date_norm
   on elig.person_id_key = date_norm.person_id_key
-left outer join {{ ref('reference_data__ansi_fips_state') }} as ansi
-  on trim(lower(elig.state)) = trim(lower(ansi.ansi_fips_state_name))
+left outer join {{ ref('normalized_input__int_eligibility_state_normalize') }} as ansi
+  on elig.person_id_key = ansi.person_id_key

--- a/models/claims_preprocessing/normalized_input/final/normalized_input__eligibility.sql
+++ b/models/claims_preprocessing/normalized_input/final/normalized_input__eligibility.sql
@@ -32,9 +32,14 @@ select
   , cast(elig.city as {{ dbt.type_string() }}) as city
   , cast(elig.state as {{ dbt.type_string() }}) as state
   , cast(elig.zip_code as {{ dbt.type_string() }}) as zip_code
+  , cast(ansi.ansi_fips_state_code as {{ dbt.type_string() }}) as fips_state_code
+  , cast(ansi.ansi_fips_state_name as {{ dbt.type_string() }}) as normalized_state_name
+  , cast(ansi.ansi_fips_state_abbreviation as {{ dbt.type_string() }}) as fips_state_abbreviation
   , cast(elig.phone as {{ dbt.type_string() }}) as phone
   , cast(elig.data_source as {{ dbt.type_string() }}) as data_source
   , cast('{{ var('tuva_last_run') }}' as {{ dbt.type_string() }}) as tuva_last_run
 from {{ ref('normalized_input__stg_eligibility') }} as elig
 left outer join {{ ref('normalized_input__int_eligibility_dates_normalize') }} as date_norm
   on elig.person_id_key = date_norm.person_id_key
+left outer join {{ ref('reference_data__ansi_fips_state') }} as ansi
+  on trim(lower(elig.state)) = trim(lower(ansi.ansi_fips_state_name))

--- a/models/claims_preprocessing/normalized_input/intermediate/normalized_input__int_eligibility_state_normalize.sql
+++ b/models/claims_preprocessing/normalized_input/intermediate/normalized_input__int_eligibility_state_normalize.sql
@@ -1,0 +1,24 @@
+{{ config(
+     enabled = var('claims_preprocessing_enabled',var('claims_enabled',var('tuva_marts_enabled',False)))
+ | as_bool
+   )
+}}
+
+
+select distinct
+    elig.person_id
+    , {{ concat_custom([
+        "elig.person_id",
+        "coalesce(elig.data_source,'')",
+        "coalesce(elig.payer,'')",
+        "coalesce(elig." ~ quote_column('plan') ~ ",'')",
+        "coalesce(cast(elig.enrollment_start_date as " ~ dbt.type_string() ~ "),'')",
+        "coalesce(cast(elig.enrollment_end_date as " ~ dbt.type_string() ~ "),'')"
+    ]) }} as person_id_key
+    , ansi.ansi_fips_state_name as normalized_state_name
+    , ansi.ansi_fips_state_code as fips_state_code
+    , ansi.ansi_fips_state_abbreviation as fips_state_abbreviation
+    , '{{ var('tuva_last_run') }}' as tuva_last_run
+from {{ ref('normalized_input__stg_eligibility') }} as elig
+left outer join {{ ref('reference_data__ansi_fips_state') }} as ansi
+  on trim(lower(elig.state)) = trim(lower(ansi.ansi_fips_state_name))

--- a/models/claims_preprocessing/normalized_input/staging/normalized_input__int_eligibility_state_normalize.sql
+++ b/models/claims_preprocessing/normalized_input/staging/normalized_input__int_eligibility_state_normalize.sql
@@ -1,3 +1,0 @@
-select
-    *
-from {{ ref('reference_data__ansi_fips_state') }}

--- a/models/claims_preprocessing/normalized_input/staging/normalized_input__int_eligibility_state_normalize.sql
+++ b/models/claims_preprocessing/normalized_input/staging/normalized_input__int_eligibility_state_normalize.sql
@@ -1,0 +1,3 @@
+select
+    *
+from {{ ref('reference_data__ansi_fips_state') }}

--- a/models/core/core_models.yml
+++ b/models/core/core_models.yml
@@ -138,6 +138,12 @@ models:
       description: '{{ doc("medicare_status_code") }}'
       meta:
         terminology: https://github.com/tuva-health/the_tuva_project/blob/main/seeds/terminology/terminology__medicare_status.csv
+    - name: fips_state_code
+      description: '{{ doc("fips_state_code") }}'
+    - name: normalized_state_name
+      description: '{{ doc("normalized_state_name") }}'
+    - name: fips_state_abbreviation
+      description: '{{ doc("fips_state_abbreviation") }}'
     - name: subscriber_relation
       description: '{{ doc("subscriber_relation") }}'
     - name: group_id

--- a/models/core/staging/core__stg_claims_eligibility.sql
+++ b/models/core/staging/core__stg_claims_eligibility.sql
@@ -41,8 +41,11 @@ select
        , cast(dual_status_code as {{ dbt.type_string() }}) as dual_status_code
        , cast(medicare_status_code as {{ dbt.type_string() }}) as medicare_status_code
        , cast(subscriber_relation as {{ dbt.type_string() }}) as subscriber_relation
-        , cast(group_id as {{ dbt.type_string() }}) as group_id
-        , cast(group_name as {{ dbt.type_string() }}) as group_name
+       , cast(group_id as {{ dbt.type_string() }}) as group_id
+       , cast(group_name as {{ dbt.type_string() }}) as group_name
+       , cast(normalized_state_name as {{ dbt.type_string() }}) as normalized_state_name
+       , cast(fips_state_code as {{ dbt.type_string() }}) as fips_state_code
+       , cast(fips_state_abbreviation as {{ dbt.type_string() }}) as fips_state_abbreviation
        , cast(data_source as {{ dbt.type_string() }}) as data_source
        , '{{ var('tuva_last_run') }}' as tuva_last_run
 from {{ ref('normalized_input__eligibility') }}


### PR DESCRIPTION
### [BREAKING CHANGE] Addition of geographic information columns in core.eligibility Table 

The `ansi_fips_state` has been referenced to `core.eligibility` table to add the `NORMALIZED_STATE_NAME`, `FIPS_STATE_CODE`, and `FIPS_STATE_ABBREVIATION` field in `core.eligibility` table.

For this purpose, a new normalization model named as `normalized_input__int_eligibility_state_normalize` has been added. 